### PR TITLE
Update PolygonGeohashUDF.java

### DIFF
--- a/src/main/java/tech/leovan/hive/udf/geo/PolygonAreaUDF.java
+++ b/src/main/java/tech/leovan/hive/udf/geo/PolygonAreaUDF.java
@@ -39,14 +39,14 @@ public class PolygonAreaUDF extends UDF {
             return null;
         }
 
-        Geometry polygon = CTX.getShapeFactory().getGeometryFrom(shape);
-        if (!(polygon instanceof Polygon || polygon instanceof MultiPolygon)) {
+        Geometry geometry = CTX.getShapeFactory().getGeometryFrom(shape);
+        if (!(geometry instanceof Polygon || geometry instanceof MultiPolygon)) {
             return null;
         }
 
         try {
             MathTransform transform = CRS.findMathTransform(SOURCE_CRS, TARGET_CRS, false);
-            Geometry geometryMercator = JTS.transform(polygon, transform);
+            Geometry geometryMercator = JTS.transform(geometry, transform);
 
             return geometryMercator.getArea();
         } catch (Exception e) {


### PR DESCRIPTION
如果是单多边形区域,直接采用原深度优先遍历方式。如果是多多边形需要按照单多边形计算后再去重合并(否则可能出现质心不在多边形内导致无geohash，或者多块区域距离较远，质心在其中一个导致只计算了一个多边形覆盖的geohash)